### PR TITLE
Who doesn't like CI? 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,35 @@
+name: Build Heltec WiFi Kit 32
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Install Arduino CLI
+        uses: arduino/setup-arduino-cli@v1.1.1
+      - name: Install Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+      - name: Install ESP32 tools
+        run: |
+          pip install esptool
+      - name: Install CLI dependencies
+        run: |
+          arduino-cli core update-index
+          arduino-cli core install Heltec-esp32:esp32
+          arduino-cli lib update-index
+          arduino-cli lib install "Heltec ESP32 Dev-Boards"
+          arduino-cli lib install "ESP32 BLE Arduino"
+      - name: Build
+        run: |
+          arduino-cli compile --fqbn Heltec-esp32:esp32:wifi_kit_32 --export-binaries mycadence-arduino
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: Heltec WiFi Kit 32
+          path: build/Heltec-esp32.esp32.wifi_kit_32/
+        

--- a/.gitignore
+++ b/.gitignore
@@ -348,3 +348,6 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+
+# ESP32 build folder
+build/

--- a/arduino-cli.yaml
+++ b/arduino-cli.yaml
@@ -1,0 +1,4 @@
+# arduino-cli.yaml
+board_manager:
+  additional_urls:
+    - https://resource.heltec.cn/download/package_heltec_esp32_index.json


### PR DESCRIPTION
I read the blog post earlier and I thought you might like a CI build added to aid with all the future pull requests 😜.

I don't actually use Arduino code usually (Merge Conflict convinced me to try out the ESP32, but I stick to the C/C++ ESP-IDF route), but I quite enjoy a challenge!

The build action uses the Arduino CLI to follow the steps in the README (plus adding the `esptool` via `pip`) and then stores the build outputs as artifacts for downloading.